### PR TITLE
For #105, #118

### DIFF
--- a/keys_generator/keys_generator.py
+++ b/keys_generator/keys_generator.py
@@ -45,7 +45,7 @@ publicKey, privateKey = get_password("AxonOpsDeveloperWorkbenchPublicKey", "key"
 # If not, then create both keys
 if publicKey is None or privateKey is None or \
         len(publicKey) != 271 or len(privateKey) != 886:
-    keys = RSA.generate(1024)  # Setting the length to 4096 caused a failure on Windows (issue #105)
+    keys = RSA.generate(2048)  # Setting the length to 4096 caused a failure on Windows (issue #105)
 
     # Get public and private keys,
     # encode them with base64, and convert them from bytes to string

--- a/keys_generator/keys_generator.py
+++ b/keys_generator/keys_generator.py
@@ -45,7 +45,7 @@ publicKey, privateKey = get_password("AxonOpsDeveloperWorkbenchPublicKey", "key"
 # If not, then create both keys
 if publicKey is None or privateKey is None or \
         len(publicKey) != 271 or len(privateKey) != 886:
-    keys = RSA.generate(2048)  # Setting the length to 4096 caused a failure on Windows (issue #105)
+    keys = RSA.generate(int(os.getenv("RSA_KEY_LENGTH", 2048))) # Setting the length to 2048 caused a failure on Windows (issue #105)
 
     # Get public and private keys,
     # encode them with base64, and convert them from bytes to string

--- a/v6.0.0-ACv4.0.7/cqlsh.py
+++ b/v6.0.0-ACv4.0.7/cqlsh.py
@@ -131,7 +131,21 @@ cqldocs = None
 cqlruleset = None
 
 if platform.system() == 'Windows':
-   set_keyring(backends.Windows.WinVaultKeyring())
+    try:
+        from keyring.backends.Windows import WinVaultKeyring
+        set_keyring(WinVaultKeyring())
+    except:
+        pass
+
+if platform.system() == 'Linux':
+    try:
+        get_password("AxonOpsDeveloperWorkbenchPublicKey", "key")
+    except:
+        try:
+            from keyring.backends import libsecret
+            set_keyring(libsecret.Keyring())
+        except:
+            pass
 
 epilog = """Connects to %(DEFAULT_HOST)s:%(DEFAULT_PORT)d by default. These
 defaults can be changed by setting $CQLSH_HOST and/or $CQLSH_PORT. When a
@@ -994,13 +1008,13 @@ class Shell(cmd.Cmd):
             if '*/' in result:
                 result = re.sub('.*[*][/]', "", result)
                 self.in_comment = False
-            if self.in_comment and not re.findall('[/][*]|[*][/]', statementtext):
+            if self.in_comment and not re.findall(r'[/][*]|[*][/]', statementtext):
                 result = ''
             return result
         return statementtext
 
     def onecmd(self, statementtext):
-        if len(re.findall("KEYWORD:STATEMENT:IGNORE-\d+", statementtext)) > 0:
+        if len(re.findall(r'KEYWORD:STATEMENT:IGNORE-\d+', statementtext)) > 0:
             return True
 
         """
@@ -2243,7 +2257,7 @@ def read_options(cmdlineargs, environment):
                     for option in options:
                         for variable in variables:
                             value = configs.get(section, option)
-                            matchedVars = re.findall("\$\{(" + variable["name"] + ")\}", value)
+                            matchedVars = re.findall(r'\${(' + variable["name"] + ')}', value)
                             for matchedVar in matchedVars:
                                 newValue = value.replace("${" + matchedVar + "}", variable["value"])
                                 configs.set(section, option, value=newValue)
@@ -2256,7 +2270,7 @@ def read_options(cmdlineargs, environment):
                     for option in options:
                         for variable in variables:
                             value = rawconfigs.get(section, option)
-                            matchedVars = re.findall("\$\{(" + variable["name"] + ")\}", value)
+                            matchedVars = re.findall(r'\${(' + variable["name"] + ')}', value)
                             for matchedVar in matchedVars:
                                 newValue = value.replace("${" + matchedVar + "}", variable["value"])
                                 rawconfigs.set(section, option, value=newValue)

--- a/v6.0.0-ACv4.0.7/cqlshlib/sslhandling.py
+++ b/v6.0.0-ACv4.0.7/cqlshlib/sslhandling.py
@@ -77,7 +77,7 @@ def ssl_settings(host, config_file, env=os.environ, varsManifest=None, varsValue
                     for option in options:
                         for variable in variables:
                             value = configs.get(section, option)
-                            matchedVars = re.findall("\$\{(" + variable["name"] + ")\}", value)
+                            matchedVars = re.findall(r"\${(" + variable["name"] + ")}", value)
                             for matchedVar in matchedVars:
                                 newValue = value.replace("${" + matchedVar + "}", variable["value"])
                                 configs.set(section, option, value=newValue)

--- a/v6.1.0-ACv4.1.0/cqlsh.py
+++ b/v6.1.0-ACv4.1.0/cqlsh.py
@@ -125,7 +125,21 @@ cqlruleset = None
 
 
 if platform.system() == 'Windows':
-   set_keyring(backends.Windows.WinVaultKeyring())
+    try:
+        from keyring.backends.Windows import WinVaultKeyring
+        set_keyring(WinVaultKeyring())
+    except:
+        pass
+
+if platform.system() == 'Linux':
+    try:
+        get_password("AxonOpsDeveloperWorkbenchPublicKey", "key")
+    except:
+        try:
+            from keyring.backends import libsecret
+            set_keyring(libsecret.Keyring())
+        except:
+            pass
 
 epilog = """Connects to %(DEFAULT_HOST)s:%(DEFAULT_PORT)d by default. These
 defaults can be changed by setting $CQLSH_HOST and/or $CQLSH_PORT. When a
@@ -963,13 +977,13 @@ class Shell(cmd.Cmd):
             if '*/' in result:
                 result = re.sub('.*[*][/]', "", result)
                 self.in_comment = False
-            if self.in_comment and not re.findall('[/][*]|[*][/]', statementtext):
+            if self.in_comment and not re.findall(r'[/][*]|[*][/]', statementtext):
                 result = ''
             return result
         return statementtext
 
     def onecmd(self, statementtext):
-        if len(re.findall("KEYWORD:STATEMENT:IGNORE-\d+", statementtext)) > 0:
+        if len(re.findall(r'KEYWORD:STATEMENT:IGNORE-\d+', statementtext)) > 0:
             return True
 
         """
@@ -2223,7 +2237,7 @@ def read_options(cmdlineargs, environment):
                     for option in options:
                         for variable in variables:
                             value = configs.get(section, option)
-                            matchedVars = re.findall("\$\{(" + variable["name"] + ")\}", value)
+                            matchedVars = re.findall(r'\${(' + variable["name"] + ')}', value)
                             for matchedVar in matchedVars:
                                 newValue = value.replace("${" + matchedVar + "}", variable["value"])
                                 configs.set(section, option, value=newValue)
@@ -2236,7 +2250,7 @@ def read_options(cmdlineargs, environment):
                     for option in options:
                         for variable in variables:
                             value = rawconfigs.get(section, option)
-                            matchedVars = re.findall("\$\{(" + variable["name"] + ")\}", value)
+                            matchedVars = re.findall(r'\${(' + variable["name"] + ')}', value)
                             for matchedVar in matchedVars:
                                 newValue = value.replace("${" + matchedVar + "}", variable["value"])
                                 rawconfigs.set(section, option, value=newValue)

--- a/v6.1.0-ACv4.1.0/cqlshlib/sslhandling.py
+++ b/v6.1.0-ACv4.1.0/cqlshlib/sslhandling.py
@@ -76,7 +76,7 @@ def ssl_settings(host, config_file, env=os.environ, varsManifest=None, varsValue
                     for option in options:
                         for variable in variables:
                             value = configs.get(section, option)
-                            matchedVars = re.findall("\$\{(" + variable["name"] + ")\}", value)
+                            matchedVars = re.findall(r"\${(" + variable["name"] + ")}", value)
                             for matchedVar in matchedVars:
                                 newValue = value.replace("${" + matchedVar + "}", variable["value"])
                                 configs.set(section, option, value=newValue)


### PR DESCRIPTION
- The project now attempts to force `keyring` module to use specific back end libraries.
	- For Windows: `WinVaultKeyring`.
	- For Linux (Ubuntu): `LibSecret`.
	- The key's length is set back to `1024`; as `4096` seems too unstable and causes crashes of the keys_generator tool on Windows.
- Improved the regular expressions in the `cqlsh` project to get rid of the warnings.
- Updated the `keyring` part in the `cqlsh` project as well.