### PR TITLE
Added support to print the custom version of the binaries

### DIFF
--- a/v6.0.0-ACv4.0.7/cqlsh.py
+++ b/v6.0.0-ACv4.0.7/cqlsh.py
@@ -17,6 +17,9 @@
 # limitations under the License.
 from __future__ import division, unicode_literals, print_function
 
+# The current release version of the binaries
+CUSTOM_VERSION = '0.10.0'
+
 import sys
 
 # Hold the original `sys.exit` function
@@ -202,9 +205,14 @@ parser.add_option("--varsValues", help="Specify the path to variables values")
 parser.add_option("--workspaceID", help="Specify the workspace ID which variables scope will be restricted to")
 parser.add_option("--overrideHost", help="Override the host used to connect")
 parser.add_option("--overridePort", help="Override the port used to connect")
+parser.add_option("--cversion", help="Just print the custom version of the binaries")
 
 optvalues = optparse.Values()
 (options, arguments) = parser.parse_args(sys.argv[1:], values=optvalues)
+
+if hasattr(options, "cversion"):
+    print(CUSTOM_VERSION)
+    sys.exit(0)
 
 givenUsername = None
 givenPassword = None

--- a/v6.0.0-ACv4.0.7/cqlsh.py
+++ b/v6.0.0-ACv4.0.7/cqlsh.py
@@ -22,6 +22,8 @@ CUSTOM_VERSION = '0.10.0'
 
 import sys
 
+isBasic = False
+
 # Hold the original `sys.exit` function
 original_exit = sys.exit
 
@@ -261,7 +263,6 @@ workspaceID = None
 if hasattr(options, "workspaceID"):
     workspaceID = options.workspaceID
 
-isBasic = False
 if hasattr(options, "basic"):
     isBasic = True
 


### PR DESCRIPTION
Using the argument `--cversion=1` with the cqlsh tool v6.0.0 we can now get the custom version of the binaries project